### PR TITLE
Remove extraneous favicon assets

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -4,6 +4,7 @@
 import '../styles/global.css';
 import { SITE_TITLE } from '../consts';
 import FallbackImage from '../assets/blog-placeholder-1.jpg';
+import FaviconLinks from './FaviconLinks.astro';
 import type { ImageMetadata } from 'astro';
 
 interface Props {
@@ -21,6 +22,7 @@ const { title, description, image = FallbackImage } = Astro.props;
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+<FaviconLinks />
 <link rel="sitemap" href="/sitemap-index.xml" />
 <link
 	rel="alternate"

--- a/src/components/FaviconLinks.astro
+++ b/src/components/FaviconLinks.astro
@@ -1,0 +1,21 @@
+---
+// Favicon and icon links to be included across the site
+---
+<link rel="apple-touch-icon" sizes="57x57" href="/favicon-57x57.png" />
+<link rel="apple-touch-icon" sizes="60x60" href="/favicon-60x60.png" />
+<link rel="apple-touch-icon" sizes="72x72" href="/favicon-72x72.png" />
+<link rel="apple-touch-icon" sizes="76x76" href="/favicon-76x76.png" />
+<link rel="apple-touch-icon" sizes="114x114" href="/favicon-114x114.png" />
+<link rel="apple-touch-icon" sizes="120x120" href="/favicon-120x120.png" />
+<link rel="apple-touch-icon" sizes="144x144" href="/favicon-144x144.png" />
+<link rel="apple-touch-icon" sizes="152x152" href="/favicon-152x152.png" />
+<link rel="apple-touch-icon" sizes="180x180" href="/favicon-180x180.png" />
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+<link rel="icon" type="image/png" sizes="96x96" href="/favicon-96x96.png" />
+<link rel="icon" type="image/png" sizes="192x192" href="/favicon-192x192.png" />
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
+<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+<meta name="msapplication-TileColor" content="#ffffff" />
+<meta name="msapplication-TileImage" content="/favicon-144x144.png" />
+<meta name="msapplication-config" content="/browserconfig.xml" />


### PR DESCRIPTION
## Summary
- remove the placeholder favicon files from `public`
- keep `FaviconLinks` component references intact

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877cefeee208327b25f022ae09351c4