### PR TITLE
Improve blog SEO

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://abderra.es/sitemap-index.xml

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -2,20 +2,21 @@
 // Import the global.css file here so that it is included on
 // all pages through the use of the <BaseHead /> component.
 import '../styles/global.css';
-import { SITE_TITLE } from '../consts';
+import { SITE_TITLE, SITE_KEYWORDS } from '../consts';
 import FallbackImage from '../assets/blog-placeholder-1.jpg';
 import FaviconLinks from './FaviconLinks.astro';
 import type { ImageMetadata } from 'astro';
 
 interface Props {
-	title: string;
-	description: string;
-	image?: ImageMetadata;
+        title: string;
+        description: string;
+        image?: ImageMetadata;
+        keywords?: string;
 }
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
-const { title, description, image = FallbackImage } = Astro.props;
+const { title, description, image = FallbackImage, keywords = SITE_KEYWORDS } = Astro.props;
 ---
 
 <!-- Global Metadata -->
@@ -43,6 +44,7 @@ const { title, description, image = FallbackImage } = Astro.props;
 <title>{title}</title>
 <meta name="title" content={title} />
 <meta name="description" content={description} />
+<meta name="keywords" content={keywords} />
 
 <!-- Open Graph / Facebook -->
 <meta property="og:type" content="website" />

--- a/src/consts.js
+++ b/src/consts.js
@@ -3,3 +3,4 @@
 
 export const SITE_TITLE = 'Soy Abderra Blog';
 export const SITE_DESCRIPTION = 'Subo contenido de Roblox y a veces hablo de programación o Roblox Studio. Aquí encontrarás recursos, anuncios y documentación.';
+export const SITE_KEYWORDS = 'Roblox, programación, Lua, Roblox Studio, tutoriales, comunidad';

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -4,6 +4,7 @@ import BaseHead from '../components/BaseHead.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import FormattedDate from '../components/FormattedDate.astro';
+import { SITE_KEYWORDS } from '../consts';
 import { Image } from 'astro:assets';
 
 type Props = CollectionEntry<'blog'>['data'];
@@ -11,9 +12,9 @@ type Props = CollectionEntry<'blog'>['data'];
 const { title, description, pubDate, updatedDate, heroImage } = Astro.props;
 ---
 
-<html lang="en">
+<html lang="es">
 	<head>
-		<BaseHead title={title} description={description} />
+                <BaseHead title={title} description={description} keywords={SITE_KEYWORDS} />
 		<style>
 			main {
 				width: calc(100% - 2em);

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -2,7 +2,7 @@
 import BaseHead from '../../components/BaseHead.astro';
 import Header from '../../components/Header.astro';
 import Footer from '../../components/Footer.astro';
-import { SITE_TITLE, SITE_DESCRIPTION } from '../../consts';
+import { SITE_TITLE, SITE_DESCRIPTION, SITE_KEYWORDS } from '../../consts';
 import { getCollection } from 'astro:content';
 import FormattedDate from '../../components/FormattedDate.astro';
 import { Image } from 'astro:assets';
@@ -13,9 +13,9 @@ const posts = (await getCollection('blog')).sort(
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang="es">
 	<head>
-		<BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
+                <BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} keywords={SITE_KEYWORDS} />
 		<style>
 			main {
 				width: 960px;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,13 +2,13 @@
 import BaseHead from "../components/BaseHead.astro";
 import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
-import { SITE_TITLE, SITE_DESCRIPTION } from "../consts";
+import { SITE_TITLE, SITE_DESCRIPTION, SITE_KEYWORDS } from "../consts";
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang="es">
 	<head>
-		<BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
+                <BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} keywords={SITE_KEYWORDS} />
 	</head>
 	<body>
 		<Header />


### PR DESCRIPTION
## Summary
- add keywords constant and robots.txt
- configure BaseHead to support keywords meta tag
- set page language to Spanish

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687b53bea6c48327a8e295a32bdfbf6d